### PR TITLE
opt: Reduce threshold for s and beta failure

### DIFF
--- a/movement/akagi.py
+++ b/movement/akagi.py
@@ -426,8 +426,9 @@ class Akagi:
             step += 1
 
             # Check for cycles
-            if step > 10_000 and abs(f_0 - f_1) > abs(f_0 - f_2):
+            if step > 1_000 and abs(f_0 - f_1) > abs(f_0 - f_2):
                 success = False
+                print("s, beta: optimization caught in cycle; terminated")
                 break
 
         self.s = s


### PR DESCRIPTION
Reduce the numbers of steps taken before checking if the optimization of
`s` and `beta` is failing due to a short cycle.