### PR TITLE
chore: Update pre-commit action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,22 +1,17 @@
 # https://github.com/pre-commit/action
 # Run all pre-commit lints
 
-name: lints
+name: pre-commit
 
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-    - name: set PY
-      run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.0.1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
Old version of pre-commit github action was triggering an error.  Update
to a more recent version.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/