### PR TITLE
fix: Wrong shape of M in minimization

### DIFF
--- a/flowstock/akagi.py
+++ b/flowstock/akagi.py
@@ -558,7 +558,7 @@ class Akagi:
         result = opt.minimize(
             self.neg_likelihood_flat,
             # Use current M as initial guess
-            x0=self.M,
+            x0=self.M.flatten(),
             args=(self.pi, self.s, self.beta, term_0_log, term_1_braces),
             method="L-BFGS-B",
             jac=jac,


### PR DESCRIPTION
The shape of M and the bounds on its values are inconsistent when minimizing it.  This appears to be due to a change in scipy over the last few years, but not fully diagnosed.

Flatten M.